### PR TITLE
fix: añadir endpoint de liveness para Kubernetes

### DIFF
--- a/src/app.controller.ts
+++ b/src/app.controller.ts
@@ -67,6 +67,18 @@ export class AppController {
   }
 
   /**
+   * Endpoint simplificado para liveness probe de Kubernetes
+   * Responde rápidamente sin cálculos adicionales para verificaciones frecuentes
+   */
+  @Get('liveness')
+  getLiveness(): any {
+    return {
+      status: 'alive',
+      timestamp: new Date().toISOString(),
+    };
+  }
+
+  /**
    * Endpoint para obtener un estado detallado del sistema
    * Proporciona información extendida sobre la aplicación y su entorno
    */

--- a/test/unit/app.controller.spec.ts
+++ b/test/unit/app.controller.spec.ts
@@ -157,6 +157,21 @@ describe('AppController', () => {
         );
       });
     });
+
+    // Test para el nuevo endpoint de liveness
+    describe('getLiveness', () => {
+      it('should return a minimal response with status alive', () => {
+        const result = appController.getLiveness();
+
+        expect(result).toHaveProperty('status', 'alive');
+        expect(result).toHaveProperty('timestamp');
+
+        // Verificar que timestamp es una fecha válida
+        const timestamp = new Date(result.timestamp);
+        expect(timestamp instanceof Date).toBe(true);
+        expect(timestamp.toString()).not.toBe('Invalid Date');
+      });
+    });
   });
 
   // Test suite para cuando el servicio externo SÍ está configurado


### PR DESCRIPTION
Se ha añadido un nuevo endpoint simplificado para la verificación de liveness de Kubernetes, que responde rápidamente con un estado 'alive' y un timestamp. También se han implementado pruebas unitarias para asegurar el correcto funcionamiento de este nuevo endpoint.